### PR TITLE
Cura 10376

### DIFF
--- a/recipes/translationextractor/conanfile.py
+++ b/recipes/translationextractor/conanfile.py
@@ -32,6 +32,9 @@ class ExtractTranslations(object):
     def _remove_pot_header(self, content: str) -> str:
         return "".join(content.splitlines(keepends = True)[20:])
 
+    def _remove_comments(self, content: str) -> str:
+        return "".join([line for line in content.splitlines(keepends = True) if not line.startswith("#")])
+
     def _load_pot_content(self) -> None:
         for pot_file in Path(self._translations_root_path).rglob("*.pot"):
             # only store the content of the pot file, not the header
@@ -40,7 +43,7 @@ class ExtractTranslations(object):
     def _is_pot_content_changed(self, pot_file: str) -> bool:
         if pot_file not in self._pot_content:
             return False
-        return self._remove_pot_header(self._pot_content[pot_file]) != self._remove_pot_header(load(self._conanfile, pot_file))
+        return self._remove_comments(self._remove_pot_header(self._pot_content[pot_file])) != self._remove_comments(self._remove_pot_header(load(self._conanfile, pot_file)))
 
     def _only_update_pot_files_when_changed(self) -> None:
         """restore the previous content of the pot files if the content hasn't changed"""
@@ -189,7 +192,7 @@ class ExtractTranslations(object):
 
 class Pkg(ConanFile):
     name = "translationextractor"
-    version = "2.1.2"
+    version = "2.1.3"
     default_user = "ultimaker"
     default_channel = "stable"
 

--- a/recipes/translationextractor/conanfile.py
+++ b/recipes/translationextractor/conanfile.py
@@ -1,12 +1,10 @@
 from pathlib import Path
-import os
 import json
-import logging
 import time
 import collections
 
 from conan import ConanFile
-from conan.tools.files import save, load
+from conan.tools.files import save, load, rm
 
 
 # Part of this script generates a POT file from a JSON settings file. It
@@ -20,17 +18,36 @@ class ExtractTranslations(object):
     def __init__(self, conanfile: ConanFile):
         self._conanfile = conanfile
         self._translations_root_path = self._conanfile.source_path.joinpath("resources", "i18n")
-        self._gettext_path = self._conanfile.dependencies["gettext"].cpp_info.bindirs[0]
         self._all_strings_pot_path = self._translations_root_path.joinpath(self._conanfile.name + ".pot")  # pot file containing all strings untranslated
+        self._pot_content = {}
+        self._pot_are_updated = False
 
     def _update_po_files_all_languages(self) -> None:
         """ Updates all po files in translation_root_path with new strings mapped to blank translations."""
         for pot_file in Path(self._translations_root_path).rglob("*.pot"):
             for po_file in Path(self._translations_root_path).rglob(str(pot_file.with_suffix(".po").name)):
-                self._conanfile.output.info(f"Updating {po_file} with {pot_file}...")
-                self._conanfile.run(
-                    f"{os.path.join(self._gettext_path, 'msgmerge')} --no-wrap --no-fuzzy-matching --sort-by-file -o {po_file} {po_file} {pot_file}",
-                    env="conanbuild")
+                self._conanfile.run(f"msgmerge --no-wrap --no-fuzzy-matching --sort-by-file -o {po_file} {po_file} {pot_file}", env = "conanbuild")
+
+    def _remove_pot_header(self, content: str) -> str:
+        return "".join(content.splitlines(keepends = True)[20:])
+
+    def _load_pot_content(self) -> None:
+        for pot_file in Path(self._translations_root_path).rglob("*.pot"):
+            # only store the content of the pot file, not the header
+            self._pot_content[str(pot_file)] = load(self._conanfile, str(pot_file))
+
+    def _is_pot_content_changed(self, pot_file: str) -> bool:
+        if pot_file not in self._pot_content:
+            return False
+        return self._remove_pot_header(self._pot_content[pot_file]) != self._remove_pot_header(load(self._conanfile, pot_file))
+
+    def _only_update_pot_files_when_changed(self) -> None:
+        """restore the previous content of the pot files if the content hasn't changed"""
+        for pot_file in Path(self._translations_root_path).rglob("*.pot"):
+            if self._is_pot_content_changed(str(pot_file)):
+                self._pot_are_updated = True
+            else:
+                save(self._conanfile, str(pot_file), self._pot_content[str(pot_file)])
 
     def _extract_strings_to_pot_files(self) -> None:
         """
@@ -50,18 +67,18 @@ class ExtractTranslations(object):
         for path in self._conanfile.source_path.rglob("*.py"):
             if "venv" in path.parts:
                 continue
-            self._conanfile.output.info(f"Extracting python strings from {path}...")
             self._conanfile.run(
-                f"{os.path.join(self._gettext_path, 'xgettext')} --from-code=UTF-8 --join-existing --sort-by-file --language=python --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
-                env="conanbuild")
+                f"xgettext --from-code=UTF-8 --join-existing --sort-by-file --language=python --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
+                env = "conanbuild")
 
     def _extract_qml(self) -> None:
         """ Extract all i18n strings from qml files inside the root path """
         for path in self._conanfile.source_path.rglob("*.qml"):
-            self._conanfile.output.info(f"Extracting python strings from {path}...")
+            if "venv" in path.parts:
+                continue
             self._conanfile.run(
-                f"{os.path.join(self._gettext_path, 'xgettext')} --from-code=UTF-8 --join-existing --sort-by-file --language=javascript --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
-                env="conanbuild")
+                f"xgettext --from-code=UTF-8 --join-existing --sort-by-file --language=javascript --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
+                env = "conanbuild")
 
     def _extract_plugin(self) -> None:
         """ Extract the name and description from all plugins """
@@ -70,23 +87,18 @@ class ExtractTranslations(object):
             translation_entries = ""
 
             # Extract translations from plugin.json
-            with open(path, "r", encoding="utf-8") as data_file:
-                plugin_dict = json.load(data_file, object_pairs_hook=collections.OrderedDict)
-
-                if "name" not in plugin_dict or (
-                        "api" not in plugin_dict and "supported_sdk_versions" not in plugin_dict) or "version" not in plugin_dict:
-                    self._conanfile.output.warn(f"The plugin.json is invalid, ignoring it: {path}")
-                else:
-                    if "description" in plugin_dict:
-                        translation_entries += self._create_translation_entry(path, "description",
-                                                                              plugin_dict["description"])
-                    if "name" in plugin_dict:
-                        translation_entries += self._create_translation_entry(path, "name", plugin_dict["name"])
+            plugin_dict = json.loads(load(self._conanfile, path), object_pairs_hook = collections.OrderedDict)
+            if "name" not in plugin_dict or ("api" not in plugin_dict and "supported_sdk_versions" not in plugin_dict) or "version" not in plugin_dict:
+                self._conanfile.output.warn(f"The plugin.json is invalid, ignoring it: {path}")
+            else:
+                if "description" in plugin_dict:
+                    translation_entries += self._create_translation_entry(path, "description", plugin_dict["description"])
+                if "name" in plugin_dict:
+                    translation_entries += self._create_translation_entry(path, "name", plugin_dict["name"])
 
             # Write plugin name & description to output pot file
             if translation_entries:
-                self._conanfile.output.info(f"Extracting plugin strings from {path}...")
-                save(self._conanfile, self._all_strings_pot_path, translation_entries, append=True)
+                save(self._conanfile, self._all_strings_pot_path, translation_entries, append = True)
 
     def _extract_settings(self) -> None:
         """ Extract strings from settings json files to pot file with a matching name """
@@ -96,17 +108,10 @@ class ExtractTranslations(object):
 
     def _write_setting_text(self, json_path: Path, destination_path: Path) -> bool:
         """ Writes settings text from json file to pot file. Returns true if a file was written. """
-        translation_entries = ""
-        with open(json_path, "r", encoding="utf-8") as data_file:
-            setting_dict = json.load(data_file, object_pairs_hook=collections.OrderedDict)
+        setting_dict = json.loads(load(self._conanfile, json_path), object_pairs_hook = collections.OrderedDict)
 
-            if "settings" not in setting_dict:
-                self._conanfile.output.info(f"Nothing to translate in file: {json_path}")
-            else:
-                translation_entries = self._process_settings(json_path.name, setting_dict["settings"])
-
-        if translation_entries:
-            self._conanfile.output.info(f"Extracting setting strings from {json_path}...")
+        if "settings" in setting_dict:
+            translation_entries = self._process_settings(json_path.name, setting_dict["settings"])
             output_pot_path = Path(destination_path).joinpath(
                 json_path.name + ".pot")  # Create a pot with a matching filename in the destination path
             content = self._create_pot_header() + translation_entries
@@ -122,15 +127,12 @@ class ExtractTranslations(object):
             if "description" in value:
                 translation_entries += self._create_setting_translation_entry(file, name, "description", value["description"])
             if "warning_description" in value:
-                translation_entries += self._create_setting_translation_entry(file, name, "warning_description",
-                                                                      value["warning_description"])
+                translation_entries += self._create_setting_translation_entry(file, name, "warning_description", value["warning_description"])
             if "error_description" in value:
-                translation_entries += self._create_setting_translation_entry(file, name, "error_description",
-                                                                      value["error_description"])
+                translation_entries += self._create_setting_translation_entry(file, name, "error_description", value["error_description"])
             if "options" in value:
                 for item, description in value["options"].items():
-                    translation_entries += self._create_setting_translation_entry(file, name, "option {0}".format(item),
-                                                                          description)
+                    translation_entries += self._create_setting_translation_entry(file, name, "option {0}".format(item), description)
             if "children" in value:
                 translation_entries += self._process_settings(file, value["children"])
 
@@ -144,12 +146,12 @@ class ExtractTranslations(object):
 
     def _create_pot_header(self) -> str:
         """ Creates a pot file header """
-        header = "#, fuzzy\n"
+        header = "#\n"
         header += "msgid \"\"\n"
         header += "msgstr \"\"\n"
         header += "\"Project-Id-Version: Uranium json setting files\\n\"\n"
         header += "\"Report-Msgid-Bugs-To: plugins@ultimaker.com\\n\"\n"
-        header += "\"POT-Creation-Date: %s+0000\\n\"\n" % time.strftime("%Y-%m-%d %H:%M")
+        header += "\"POT-Creation-Date: {}+0000\\n\"\n".format(time.strftime("%Y-%m-%d %H:%M"))
         header += "\"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n\"\n"
         header += "\"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n\"\n"
         header += "\"Language-Team: LANGUAGE\\n\"\n"
@@ -157,17 +159,31 @@ class ExtractTranslations(object):
         header += "\"Content-Type: text/plain; charset=UTF-8\\n\"\n"
         header += "\"Content-Transfer-Encoding: 8bit\\n\"\n"
         header += "\n"
+        header += "\n"
+        header += "\n"
+        header += "\n"
+        header += "\n"
+        header += "\n"
         return header
 
     def _sanitize_pot_files(self) -> None:
         """ Sanitize all pot files """
         for path in self._translations_root_path.rglob("*.pot"):
-            save(self._conanfile, path, load(self._conanfile, path).replace(f"#: {self._conanfile.source_path}/", "#: ").replace("charset=CHARSET", "charset=UTF-8"))
+            content = load(self._conanfile, path)
+            if "msgctxt" not in content:
+                self._conanfile.output.warn(f"Removing empty pot file: {path}")
+                rm(self._conanfile, path.name, path.parent)
+            else:
+                save(self._conanfile, path, content.replace(f"#: {self._conanfile.source_path}/", "#: ").replace("charset=CHARSET", "charset=UTF-8"))
 
     def generate(self):
+        self._load_pot_content()
         self._extract_strings_to_pot_files()
         self._sanitize_pot_files()
-        self._update_po_files_all_languages()
+        self._only_update_pot_files_when_changed()
+        if self._pot_are_updated:
+            self._conanfile.output.info("Translation Templates contain new strings. Updating po files...")
+            self._update_po_files_all_languages()
 
 
 class Pkg(ConanFile):

--- a/recipes/translationextractor/conanfile.py
+++ b/recipes/translationextractor/conanfile.py
@@ -26,7 +26,7 @@ class ExtractTranslations(object):
         """ Updates all po files in translation_root_path with new strings mapped to blank translations."""
         for pot_file in Path(self._translations_root_path).rglob("*.pot"):
             for po_file in Path(self._translations_root_path).rglob(str(pot_file.with_suffix(".po").name)):
-                self._conanfile.run(f"msgmerge --no-wrap --no-fuzzy-matching --sort-by-file -o {po_file} {po_file} {pot_file}", env = "conanbuild")
+                self._conanfile.run(f"msgmerge --no-wrap --no-fuzzy-matching --sort-by-file -o {po_file} {po_file} {pot_file}", env = "conanbuild", run_environment = True)
 
     def _remove_pot_header(self, content: str) -> str:
         return "".join(content.splitlines(keepends = True)[20:])
@@ -69,7 +69,7 @@ class ExtractTranslations(object):
                 continue
             self._conanfile.run(
                 f"xgettext --from-code=UTF-8 --join-existing --sort-by-file --language=python --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
-                env = "conanbuild")
+                env = "conanbuild", run_environment = True)
 
     def _extract_qml(self) -> None:
         """ Extract all i18n strings from qml files inside the root path """
@@ -78,7 +78,7 @@ class ExtractTranslations(object):
                 continue
             self._conanfile.run(
                 f"xgettext --from-code=UTF-8 --join-existing --sort-by-file --language=javascript --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
-                env = "conanbuild")
+                env = "conanbuild", run_environment = True)
 
     def _extract_plugin(self) -> None:
         """ Extract the name and description from all plugins """
@@ -188,7 +188,7 @@ class ExtractTranslations(object):
 
 class Pkg(ConanFile):
     name = "translationextractor"
-    version = "2.1.0"
+    version = "2.1.1"
     default_user = "ultimaker"
     default_channel = "stable"
 

--- a/recipes/translationextractor/conanfile.py
+++ b/recipes/translationextractor/conanfile.py
@@ -15,8 +15,9 @@ from conan.tools.files import save, load, rm
 
 
 class ExtractTranslations(object):
-    def __init__(self, conanfile: ConanFile):
+    def __init__(self, conanfile: ConanFile, gettext_bindir):
         self._conanfile = conanfile
+        self._gettext_bindir = gettext_bindir
         self._translations_root_path = self._conanfile.source_path.joinpath("resources", "i18n")
         self._all_strings_pot_path = self._translations_root_path.joinpath(self._conanfile.name + ".pot")  # pot file containing all strings untranslated
         self._pot_content = {}
@@ -26,7 +27,7 @@ class ExtractTranslations(object):
         """ Updates all po files in translation_root_path with new strings mapped to blank translations."""
         for pot_file in Path(self._translations_root_path).rglob("*.pot"):
             for po_file in Path(self._translations_root_path).rglob(str(pot_file.with_suffix(".po").name)):
-                self._conanfile.run(f"msgmerge --no-wrap --no-fuzzy-matching --sort-by-file -o {po_file} {po_file} {pot_file}", env = "conanbuild", run_environment = True)
+                self._conanfile.run(f"{self._gettext_bindir}/msgmerge --no-wrap --no-fuzzy-matching --sort-by-file -o {po_file} {po_file} {pot_file}", env = "conanbuild", run_environment = True)
 
     def _remove_pot_header(self, content: str) -> str:
         return "".join(content.splitlines(keepends = True)[20:])
@@ -68,7 +69,7 @@ class ExtractTranslations(object):
             if "venv" in path.parts:
                 continue
             self._conanfile.run(
-                f"xgettext --from-code=UTF-8 --join-existing --sort-by-file --language=python --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
+                f"{self._gettext_bindir}/xgettext --from-code=UTF-8 --join-existing --sort-by-file --language=python --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
                 env = "conanbuild", run_environment = True)
 
     def _extract_qml(self) -> None:
@@ -77,7 +78,7 @@ class ExtractTranslations(object):
             if "venv" in path.parts:
                 continue
             self._conanfile.run(
-                f"xgettext --from-code=UTF-8 --join-existing --sort-by-file --language=javascript --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
+                f"{self._gettext_bindir}/xgettext --from-code=UTF-8 --join-existing --sort-by-file --language=javascript --no-wrap -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -o {self._all_strings_pot_path} {path}",
                 env = "conanbuild", run_environment = True)
 
     def _extract_plugin(self) -> None:
@@ -188,7 +189,7 @@ class ExtractTranslations(object):
 
 class Pkg(ConanFile):
     name = "translationextractor"
-    version = "2.1.1"
+    version = "2.1.2"
     default_user = "ultimaker"
     default_channel = "stable"
 

--- a/recipes/translationextractor/conanfile.py
+++ b/recipes/translationextractor/conanfile.py
@@ -188,7 +188,7 @@ class ExtractTranslations(object):
 
 class Pkg(ConanFile):
     name = "translationextractor"
-    version = "2.0.0"
+    version = "2.1.0"
     default_user = "ultimaker"
     default_channel = "stable"
 


### PR DESCRIPTION
Changed the translator build helper.

- when running commands in Conan you should use the `conanfile.run()` because it is then aware of build/run environment. Don't use subprocess.