### PR TITLE
CURA-10951_gh_build_curapackage

### DIFF
--- a/recipes/pyprojecttoolchain/conanfile.py
+++ b/recipes/pyprojecttoolchain/conanfile.py
@@ -40,7 +40,7 @@ class ToolSipMetadataBlock(Block):
     home-page = "{{ url }}"
     author = "{{ author }}"
     license = "{{ license }}"
-    description-file = "README.md"
+    description-file = "{{ description_file }}"
     requires-python = ">={{ python_version }}"
     """)
 
@@ -69,7 +69,40 @@ class ToolSipMetadataBlock(Block):
             "url": self._conanfile.url,
             "author": self._conanfile.author,
             "license": self._conanfile.license,
+            "description_file":  "README.md",
             "python_version": python_version
+        }
+
+
+class ToolSipProjectPyQtBuilder(Block):
+    template = textwrap.dedent("""
+    {% if link_full_dll %}link-full-dll = true
+    {% endif %}py-pylib-dir = "{{ py_pylib_dir }}"
+    py-pylib-lib = "{{ py_pylib_lib }}"
+    {% if py_pylib_shlib is not none %}py-pylib-shlib = "{{ py_pylib_shlib }}"
+    {% endif %}qml-debug = {{ qml_debug | lower }}
+    """)
+
+    def context(self):
+        py_lib = self._conanfile.options.get_safe("py_lib")
+        py_lib_dir = self._conanfile.options.get_safe("py_lib_dir")
+
+        if py_lib_dir is None:
+            try:
+                py_lib_dir = Path(self._conanfile.deps_cpp_info['cpython'].rootpath, self._conanfile.deps_cpp_info['cpython'].components["python"].bindirs[0], "libs").as_posix()
+                py_lib = self._conanfile.deps_cpp_info['cpython'].libs[0]
+            except:
+                self._conanfile.output.warn(
+                    "No include directory set for Python.h, either add the options: 'py_include' of add cpython as a Conan dependency!")
+        else:
+            py_lib_dir = Path(py_lib_dir).as_posix()
+
+        return {
+            "link_full_dll": self._conanfile.settings.get_safe("os") == "Windows" and self._conanfile.options.get_safe("shared", True),
+            "py_pylib_dir": py_lib_dir,
+            "py_pylib_lib": py_lib,
+            "py_pylib_shlib": py_lib,
+            "qml_debug": self._conanfile.settings.get_safe("build_type", "Release") == "Debug"
         }
 
 
@@ -77,13 +110,13 @@ class ToolSipProjectBlock(Block):
     template = textwrap.dedent("""
     [tool.sip.project]
     compile = {{ compile | lower }}
-    sip-files-dir = "{{ sip_files_dir }}"
+    {% if sip_files_dir is not none %}sip-files-dir = "{{ sip_files_dir }}"
+    {% endif %}
     build-dir = "{{ build_folder }}"
     target-dir = "{{ package_folder }}"
     {{ py_include_dir }}
     {{ py_major_version }}
-    {{ py_minor_version }}
-    """)
+    {{ py_minor_version }}""")
 
     def context(self):
         python_version = self._conanfile.options.get_safe("py_version")
@@ -100,14 +133,13 @@ class ToolSipProjectBlock(Block):
 
         if python_version is not None:
             py_version = Version(python_version)
-            py_major_version = py_version.major
-            py_minor_version = py_version.minor
 
             if py_include_dir is None:
                 try:
+                    header_path = "" if self._conanfile.settings.os == "Windows" else f"python{py_version.major}.{py_version.minor}"
                     py_include_dir = Path(self._conanfile.deps_cpp_info['cpython'].rootpath,
-                                          self._conanfile.deps_cpp_info['cpython'].includedirs[0],
-                                          f"python{py_major_version}.{py_minor_version}").as_posix()
+                                          self._conanfile.deps_cpp_info['cpython'].components["python"].includedirs[0],
+                                          header_path).as_posix()
                     py_include_dir = f"py-include-dir = \"{py_include_dir}\""
                 except:
                     self._conanfile.output.warn(
@@ -119,15 +151,17 @@ class ToolSipProjectBlock(Block):
             py_minor_version = f"py-minor-version = {py_version.minor}"
 
         if self._conanfile.package_folder:
-            package_folder = Path(self._conanfile.package_folder, "site-packages").as_posix()
+            package_folder = str(Path(self._conanfile.package_folder, "site-packages").as_posix())
         else:
-            package_folder = Path(self._conanfile.build_folder, "site-packages").as_posix()
-        sip_files_dir = Path(self._conanfile.source_folder, self._conanfile.name).as_posix()
+            package_folder = str(Path(self._conanfile.build_folder, "site-packages").as_posix())
 
+        sip_files_dir = str(Path(self._conanfile.source_folder, self._conanfile.name).as_posix())
+
+        build_folder = str(Path(self._conanfile.build_folder).joinpath("sip").as_posix())
         return {
             "sip_files_dir": sip_files_dir,
             "compile": False,
-            "build_folder": Path(self._conanfile.build_folder).as_posix(),
+            "build_folder": build_folder,
             "package_folder": package_folder,
             "py_include_dir": py_include_dir,
             "py_major_version": py_major_version,
@@ -157,7 +191,7 @@ class ToolSipBindingBlockCompile(Block):
     def context(self):
         return {
             "compileargs": list(filter(lambda item: item is not None and item != '', self._toolchain.cxxflags)),
-            "linkargs":  list(filter(lambda item: item is not None and item != '', self._toolchain.ldflags)),
+            "linkargs": list(filter(lambda item: item is not None and item != '', self._toolchain.ldflags)),
         }
 
 
@@ -210,14 +244,21 @@ class PyProjectToolchain(AutotoolsToolchain):
     def __init__(self, conanfile: ConanFile, namespace = None):
         super().__init__(conanfile, namespace)
         check_using_build_profile(self._conanfile)
-        self.blocks = ToolchainBlocks(self._conanfile, self, [
+
+        blocks = [
             ("build_system", BuildSystemBlock),
             ("tool_sip_metadata", ToolSipMetadataBlock),
-            ("tool_sip_project", ToolSipProjectBlock),
-            ("tool_sip_bindings", ToolSipBindingsBlock),
-            ("extra_sources", ToolSipBindingsExtraSourcesBlock),
-            ("compiling", ToolSipBindingBlockCompile),
-        ])
+            ("tool_sip_project", ToolSipProjectBlock)]
+
+        if "PyQt-builder" in str(self._conanfile.options.get_safe("py_build_requires", "")):
+            blocks.append(("pyqt_builder", ToolSipProjectPyQtBuilder))
+
+        blocks.extend([("tool_sip_bindings", ToolSipBindingsBlock),
+                       ("extra_sources", ToolSipBindingsExtraSourcesBlock),
+                       ("compiling", ToolSipBindingBlockCompile),
+                       ])
+
+        self.blocks = ToolchainBlocks(self._conanfile, self, blocks)
 
     @property
     def _context(self):
@@ -242,6 +283,6 @@ class PyProjectToolchain(AutotoolsToolchain):
 
 class PyProjectToolchainPkg(ConanFile):
     name = "pyprojecttoolchain"
-    version = "0.1.5"
+    version = "0.1.7"
     default_user = "ultimaker"
     default_channel = "stable"

--- a/recipes/sipbuildtool/SIPMacros.cmake
+++ b/recipes/sipbuildtool/SIPMacros.cmake
@@ -18,15 +18,15 @@ function(add_sip_module MODULE_TARGET)
     list(LENGTH SIP_FILES _no_outputfiles)
     foreach(_concat_file_nr RANGE 0 ${_no_outputfiles})
         if(${_concat_file_nr} LESS 8)
-            list(APPEND _sip_output_files "${CMAKE_CURRENT_BINARY_DIR}/${MODULE_TARGET}/sip${MODULE_TARGET}part${_concat_file_nr}.cpp")
+            list(APPEND _sip_output_files "${CMAKE_CURRENT_BINARY_DIR}/sip/${MODULE_TARGET}/sip${MODULE_TARGET}part${_concat_file_nr}.cpp")
         endif()
     endforeach()
 
     # Find the generated source files
     message(STATUS "SIP: Collecting the generated source files")
-    file(GLOB sip_c "${CMAKE_CURRENT_BINARY_DIR}/${MODULE_TARGET}/*.c")
-    file(GLOB sip_cpp "${CMAKE_CURRENT_BINARY_DIR}/${MODULE_TARGET}/*.cpp")
-    file(GLOB sip_hdr "${CMAKE_CURRENT_BINARY_DIR}/${MODULE_TARGET}/*.h")
+    file(GLOB sip_c "${CMAKE_CURRENT_BINARY_DIR}/sip/${MODULE_TARGET}/*.c")
+    file(GLOB sip_cpp "${CMAKE_CURRENT_BINARY_DIR}/sip/${MODULE_TARGET}/*.cpp")
+    file(GLOB sip_hdr "${CMAKE_CURRENT_BINARY_DIR}/sip/${MODULE_TARGET}/*.h")
 
     # Add the user specified source files
     message(STATUS "SIP: Collecting the user specified source files")
@@ -53,7 +53,7 @@ function(add_sip_module MODULE_TARGET)
 
     set_target_properties("sip_${MODULE_TARGET}"
             PROPERTIES
-            RESOURCE "${CMAKE_CURRENT_BINARY_DIR}/${MODULE_TARGET}/${MODULE_TARGET}/${MODULE_TARGET}.pyi")
+            RESOURCE "${CMAKE_CURRENT_BINARY_DIR}/sip/${MODULE_TARGET}/${MODULE_TARGET}/${MODULE_TARGET}.pyi")
 endfunction()
 
 function(install_sip_module MODULE_TARGET)

--- a/recipes/sipbuildtool/conanfile.py
+++ b/recipes/sipbuildtool/conanfile.py
@@ -35,7 +35,7 @@ class SipBuildTool(object):
 
 class Pkg(ConanFile):
     name = "sipbuildtool"
-    version = "0.2.2"
+    version = "0.2.3"
     default_user = "ultimaker"
     default_channel = "stable"
     exports_sources = "SIPMacros.cmake"

--- a/recipes/sipbuildtool/conanfile.py
+++ b/recipes/sipbuildtool/conanfile.py
@@ -35,7 +35,7 @@ class SipBuildTool(object):
 
 class Pkg(ConanFile):
     name = "sipbuildtool"
-    version = "0.2.3"
+    version = "0.2.4"
     default_user = "ultimaker"
     default_channel = "stable"
     exports_sources = "SIPMacros.cmake"

--- a/recipes/standardprojectsettings/StandardProjectSettings.cmake
+++ b/recipes/standardprojectsettings/StandardProjectSettings.cmake
@@ -1,0 +1,220 @@
+include(GNUInstallDirs) # Standard install dirs
+
+# Generate compile_commands.json to make it easier to work with clang based tools
+message(STATUS "Generating compile commands to ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Ultimaker uniform Thread linking method
+function(use_threads project_name)
+    message(STATUS "Enabling threading support for ${project_name}")
+    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+    find_package(Threads)
+    get_target_property(type ${project_name} TYPE)
+    if(CMAKE_USE_PTHREADS_INIT AND UNIX AND NOT APPLE)
+        target_link_libraries(Threads::Threads INTERFACE -pthread)
+    endif()
+    if (${type} STREQUAL "INTERFACE_LIBRARY")
+        target_link_libraries(${project_name} INTERFACE Threads::Threads)
+    else()
+        target_link_libraries(${project_name} PRIVATE Threads::Threads)
+    endif()
+endfunction()
+
+# https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
+function(set_project_warnings project_name)
+    message(STATUS "Setting warnings for ${project_name}")
+    set(MSVC_WARNINGS
+            /W4 # Baseline reasonable warnings
+            /w14242 # 'identifier': conversion from 'type1' to 'type1', possible loss of data
+            /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+            /w14263 # 'function': member function does not override any base class virtual member function
+            /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
+            # be destructed correctly
+            /w14287 # 'operator': unsigned/negative constant mismatch
+            /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
+            # the for-loop scope
+            /w14296 # 'operator': expression is always 'boolean_value'
+            /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
+            /w14545 # expression before comma evaluates to a function which is missing an argument list
+            /w14546 # function call before comma missing argument list
+            /w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
+            /w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
+            /w14555 # expression has no effect; expected expression with side- effect
+            /w14619 # pragma warning: there is no warning number 'number'
+            /w14640 # Enable warning on thread un-safe static member initialization
+            /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected runtime behavior.
+            /w14905 # wide string literal cast to 'LPSTR'
+            /w14906 # string literal cast to 'LPWSTR'
+            /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
+            /permissive- # standards conformance mode for MSVC compiler.
+            )
+
+    set(CLANG_WARNINGS
+            -Wall
+            -Wextra # reasonable and standard
+            -Wshadow # warn the user if a variable declaration shadows one from a parent context
+            -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor. This helps
+            # catch hard to track down memory errors
+            -Wold-style-cast # warn for c-style casts
+            -Wcast-align # warn for potential performance problem casts
+            -Wunused # warn on anything being unused
+            -Woverloaded-virtual # warn if you overload (not override) a virtual function
+            -Wpedantic # warn if non-standard C++ is used
+            -Wconversion # warn on type conversions that may lose data
+            -Wsign-conversion # warn on sign conversions
+            -Wnull-dereference # warn if a null dereference is detected
+            -Wdouble-promotion # warn if float is implicit promoted to double
+            -Wformat=2 # warn on security issues around functions that format output (ie printf)
+            )
+
+    set(GCC_WARNINGS
+            ${CLANG_WARNINGS}
+            -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
+            -Wduplicated-cond # warn if if / else chain has duplicated conditions
+            -Wduplicated-branches # warn if if / else branches have duplicated code
+            -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
+            -Wuseless-cast # warn if you perform a cast to the same type
+            )
+
+    if(MSVC)
+        set(PROJECT_WARNINGS ${MSVC_WARNINGS})
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+        set(PROJECT_WARNINGS ${CLANG_WARNINGS})
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set(PROJECT_WARNINGS ${GCC_WARNINGS})
+    else()
+        message(AUTHOR_WARNING "No compiler warnings set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
+    endif()
+
+    get_target_property(type ${project_name} TYPE)
+    if (${type} STREQUAL "INTERFACE_LIBRARY")
+        target_compile_options(${project_name} INTERFACE ${PROJECT_WARNINGS})
+    else()
+        target_compile_options(${project_name} PRIVATE ${PROJECT_WARNINGS})
+    endif()
+endfunction()
+
+# This function will prevent in-source builds
+function(AssureOutOfSourceBuilds)
+    # make sure the user doesn't play dirty with symlinks
+    get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+    get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+
+    # disallow in-source builds
+    if("${srcdir}" STREQUAL "${bindir}")
+        message("######################################################")
+        message("Warning: in-source builds are disabled")
+        message("Please create a separate build directory and run cmake from there")
+        message("######################################################")
+        message(FATAL_ERROR "Quitting configuration")
+    endif()
+endfunction()
+
+function(enable_sanitizers project_name)
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+        option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
+
+        if(ENABLE_COVERAGE)
+            target_compile_options(${project_name} INTERFACE --coverage -O0 -g)
+            target_link_libraries(${project_name} INTERFACE --coverage)
+        endif()
+
+        set(SANITIZERS "")
+
+        option(ENABLE_SANITIZER_ADDRESS "Enable address sanitizer" FALSE)
+        if(ENABLE_SANITIZER_ADDRESS)
+            list(APPEND SANITIZERS "address")
+        endif()
+
+        option(ENABLE_SANITIZER_LEAK "Enable leak sanitizer" FALSE)
+        if(ENABLE_SANITIZER_LEAK)
+            list(APPEND SANITIZERS "leak")
+        endif()
+
+        option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR "Enable undefined behavior sanitizer" FALSE)
+        if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR)
+            list(APPEND SANITIZERS "undefined")
+        endif()
+
+        option(ENABLE_SANITIZER_THREAD "Enable thread sanitizer" FALSE)
+        if(ENABLE_SANITIZER_THREAD)
+            if("address" IN_LIST SANITIZERS OR "leak" IN_LIST SANITIZERS)
+                message(WARNING "Thread sanitizer does not work with Address and Leak sanitizer enabled")
+            else()
+                list(APPEND SANITIZERS "thread")
+            endif()
+        endif()
+
+        option(ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" FALSE)
+        if(ENABLE_SANITIZER_MEMORY AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+            if("address" IN_LIST SANITIZERS
+                    OR "thread" IN_LIST SANITIZERS
+                    OR "leak" IN_LIST SANITIZERS)
+                message(WARNING "Memory sanitizer does not work with Address, Thread and Leak sanitizer enabled")
+            else()
+                list(APPEND SANITIZERS "memory")
+            endif()
+        endif()
+
+        list(
+                JOIN
+                SANITIZERS
+                ","
+                LIST_OF_SANITIZERS)
+
+    endif()
+
+    if(LIST_OF_SANITIZERS)
+        if(NOT
+                "${LIST_OF_SANITIZERS}"
+                STREQUAL
+                "")
+            target_compile_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
+            target_link_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
+        endif()
+    endif()
+
+endfunction()
+
+option(ENABLE_CPPCHECK "Enable static analysis with cppcheck" OFF)
+option(ENABLE_CLANG_TIDY "Enable static analysis with clang-tidy" OFF)
+option(ENABLE_INCLUDE_WHAT_YOU_USE "Enable static analysis with include-what-you-use" OFF)
+
+if(ENABLE_CPPCHECK)
+    find_program(CPPCHECK cppcheck)
+    if(CPPCHECK)
+        message(STATUS "Using cppcheck")
+        set(CMAKE_CXX_CPPCHECK
+                ${CPPCHECK}
+                --suppress=missingInclude
+                --enable=all
+                --inline-suppr
+                --inconclusive
+                -i
+                ${CMAKE_SOURCE_DIR}/imgui/lib)
+    else()
+        message(WARNING "cppcheck requested but executable not found")
+    endif()
+endif()
+
+if(ENABLE_CLANG_TIDY)
+    find_program(CLANGTIDY clang-tidy)
+    if(CLANGTIDY)
+        message(STATUS "Using clang-tidy")
+        set(CMAKE_CXX_CLANG_TIDY ${CLANGTIDY} -extra-arg=-Wno-unknown-warning-option)
+    else()
+        message(WARNING "clang-tidy requested but executable not found")
+    endif()
+endif()
+
+if(ENABLE_INCLUDE_WHAT_YOU_USE)
+    find_program(INCLUDE_WHAT_YOU_USE include-what-you-use)
+    if(INCLUDE_WHAT_YOU_USE)
+        message(STATUS "Using include-what-you-use")
+        set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${INCLUDE_WHAT_YOU_USE})
+    else()
+        message(WARNING "include-what-you-use requested but executable not found")
+    endif()
+endif()

--- a/recipes/standardprojectsettings/conanfile.py
+++ b/recipes/standardprojectsettings/conanfile.py
@@ -1,0 +1,24 @@
+from os import path
+
+from conan import ConanFile
+from conan.tools.files import copy
+
+
+class Pkg(ConanFile):
+    name = "standardprojectsettings"
+    version = "0.1.1"
+    default_user = "ultimaker"
+    default_channel = "stable"
+    exports_sources = "StandardProjectSettings.cmake"
+    package_type = "build-scripts"
+
+    def package(self):
+        copy(self, "StandardProjectSettings.cmake", src = self.export_sources_folder, dst = path.join(self.package_folder, "res", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.bindirs = []
+
+        self.cpp_info.set_property("name", "standardprojectsettings")
+        self.cpp_info.set_property("cmake_build_modules", [path.join("res", "cmake", "StandardProjectSettings.cmake")])


### PR DESCRIPTION
On Windows the pyprojecttoolchain used the the build folder as output for the sip-generated files, this folder was created before setuptools.py ran by conan. By adding a specific sip folder and changing the SIP CMake macros to use that folder. setuptools should generate the sip c files and headers and cmake should builds the binaries from those files.


The two updated recipes are already in use btw: with `conan export-pkg .` and a `conan upload ... -r cura` which needs to be done by hand anyhow in this repo, since we don't have CI/CD setup yet.