### PR TITLE
Fix some translations entries

### DIFF
--- a/recipes/translationextractor/all/conanfile.py
+++ b/recipes/translationextractor/all/conanfile.py
@@ -155,7 +155,7 @@ class ExtractTranslations(object):
         return "msgctxt \"{0} {1}\"\nmsgid \"{2}\"\nmsgstr \"\"\n\n".format(setting, field, value.replace("\n", "\\n").replace("\"", "\\\""))
 
     def _create_translation_entry(self, filename: str, field: str, value: str) -> str:
-        return "msgctxt \"{0}\"\nmsgid \"{1}\"\nmsgstr \"\"\n\n".format(field, value.replace("\n", "\\n").replace("\"", "\\\""))
+        return "\nmsgctxt \"{0}\"\nmsgid \"{1}\"\nmsgstr \"\"\n".format(field, value.replace("\n", "\\n").replace("\"", "\\\""))
 
     def _create_pot_header(self) -> str:
         """ Creates a pot file header """


### PR DESCRIPTION
When starting to generate the plugin descriptions/names entries, we miss a blank line above the first setting, which confuses gettext and loses the context for this translation. Now we always insert a blank line before and one after, instead of two after.