### PR TITLE
NP-346 add updates to emsdk recipe and fix for nodejs recipe

### DIFF
--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -74,9 +74,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-conan-downloads-
 
-      # TODO: Change to main once merged
+      # TODO: Change NP-346 to main once merged
       - name: Export changed recipes
         run: |
           mkdir runner_scripts
-          wget https://raw.githubusercontent.com/Ultimaker/cura-workflows/main/runner_scripts/upload_conan_recipes.py -O runner_scripts/upload_conan_recipes.py
+          wget https://raw.githubusercontent.com/Ultimaker/cura-workflows/NP-346/runner_scripts/upload_conan_recipes.py -O runner_scripts/upload_conan_recipes.py
           python runner_scripts/upload_conan_recipes.py --user ultimaker --branch ${{ github.ref_name }} --remote cura ${{ env.GIT_DIFF_FILTERED }}

--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - 'CURA-*'
+      - 'NP-*'
 
 permissions:
   contents: read
@@ -30,7 +31,7 @@ jobs:
         with:
           PATTERNS: |
             recipes/**/*.*
-            
+
       - name: Sync pip requirements
         run: wget https://raw.githubusercontent.com/Ultimaker/cura-workflows/main/.github/workflows/requirements-runner.txt -O .github/workflows/requirements-runner.txt
 

--- a/recipes/emsdk/all/conandata.yml
+++ b/recipes/emsdk/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "3.1.71":
     url: "https://github.com/emscripten-core/emsdk/archive/3.1.71.tar.gz"
     sha256: "ea1bbd1974a3323710fc6e585aad20b056fed634df11db2ee3556bfd18e96afd"
+  "3.1.70":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.70.tar.gz"
+    sha256: "5aa3fcdfbc3812419e9c73a5147ca9f9fdda897e05f24161813df14b35fcd7a5"
   "3.1.65":
     url: "https://github.com/emscripten-core/emsdk/archive/3.1.65.tar.gz"
     sha256: "6000c66fc5ca81117cbf9f0fd72e288992915bc16df9e6d77c607fab05b472eb"

--- a/recipes/emsdk/all/conandata.yml
+++ b/recipes/emsdk/all/conandata.yml
@@ -1,0 +1,82 @@
+sources:
+  "3.1.50":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.50.tar.gz"
+    sha256: "7491a881eb5ee15fe81bbabcfff1fd571e45ccdb24a81890af429f9970cbd1f3"
+  "3.1.49":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.49.tar.gz"
+    sha256: "c99d98da9241c7e72784bc764a3e60a65d8f27202d45f3cd422b2ac7245380d9"
+  "3.1.48":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.48.tar.gz"
+    sha256: "94b965ba8f2ff0949ff67c6943bf5638a1b8850e4491a25413cdaff5b18da42b"
+  "3.1.47":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.47.tar.gz"
+    sha256: "a882560a83cbacec67867e7ce6b00420d557e71c501b523d2ed956ded021f9b4"
+  "3.1.46":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.46.tar.gz"
+    sha256: "5dd94e557b720800a60387ec078bf3b3a527cbd916ad74a696fe399f1544474f"
+  "3.1.45":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.45.tar.gz"
+    sha256: "8b5b3433eb732dcc7643a2707a12fd5cbe793a5dadbbae9a60c24a737a78fe33"
+  "3.1.44":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.44.tar.gz"
+    sha256: "cb8cded78f6953283429d724556e89211e51ac4d871fcf38e0b32405ee248e91"
+  "3.1.31":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.31.tar.gz"
+    sha256: "1d38b7375e12e85197165a4c51d76d90e1d9db8c2c593b64cfaec4338af54750"
+  "3.1.30":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.30.tar.gz"
+    sha256: "7b9c4e0b19f08df9f0d807112926f3908fe73a2960b752a87c3862956da8b9a8"
+  "3.1.29":
+    url: "https://github.com/emscripten-core/emsdk/archive/refs/tags/3.1.29.tar.gz"
+    sha256: "506376d0d2a71fc3dd1a4dba6fb4cf18f0a2fa4e1936aa04ba4b59f2d435bf3f"
+  "3.1.23":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.23.tar.gz"
+    sha256: "a2609fd97580e4e332acbf49b6cc363714982f06cb6970d54c9789df8e91381c"
+  "3.1.20":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.20.tar.gz"
+    sha256: "fd336c6d3e51c7205a8ec68e835c442dcbb187f92e50c42b3d7d54a312072ef7"
+  "3.1.18":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.18.tar.gz"
+    sha256: "6479c60710bfb1d146a8bdd8619b693699e73185c850a6eb79ef2bd7e2a8e411"
+  "3.1.17":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.17.tar.gz"
+    sha256: "f52359d3f265162dc875ac4c9d4570abc9d012e30bef8d380cb74f0e427800a3"
+  "3.1.16":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.16.tar.gz"
+    sha256: "0a7a822e09bb22d081a49bf4229377689aef473376f36b5fe62db040d7e1c065"
+  "3.1.15":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.15.tar.gz"
+    sha256: "74c7c54b3544555ec38d1e9dcc7e90b9f49ed0e04f2cc3fd44663c598af24124"
+  "3.1.12":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.12.tar.gz"
+    sha256: "1b8d8fdebf9f155131ba74f91d2c0dd572b2ba5d1d4a22fb123d20d3ca258e30"
+  "3.1.7":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.7.tar.gz"
+    sha256: "bcceced0b7cad2e08375adf74ef20fa431230abbae8766bdad268c43e34f8d03"
+  "3.1.5":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.5.tar.gz"
+    sha256: "ae540d681aa04f32b92afbda1c9ef737aa03c81222c1ce3fd567de5af7d36625"
+  "3.1.4":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.4.tar.gz"
+    sha256: "7dc13d967705582e11ff62ae143425dbc63c38372f1a1b14f0cb681fda413714"
+  "3.1.3":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.3.tar.gz"
+    sha256: "c03767ad4b6d24f143c0a4922735c80ec17d745191ebf54b8f97dbe5d81eb52f"
+  "3.1.0":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.0.tar.gz"
+    sha256: "a2c5f3cf36525cf6a4b569f9d25500e3b2f7341c6e6779b54bcf4703b834202d"
+  "3.0.1":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.0.1.tar.gz"
+    sha256: "3a51e17d45878a5c6d1b6c20f35d308b95d58d56dbfbee4ec058e2ee216b2c90"
+  "3.0.0":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.0.0.tar.gz"
+    sha256: "a41dccfd15be9e85f923efaa0ac21943cbab77ec8d39e52f25eca1ec61a9ac9e"
+  "2.0.34":
+    url: "https://github.com/emscripten-core/emsdk/archive/2.0.34.tar.gz"
+    sha256: "a96ddf34de8de779c78be2785df04ae63c9a557da9e83e85332cda3d01bca250"
+  "2.0.31":
+    url: "https://github.com/emscripten-core/emsdk/archive/2.0.31.tar.gz"
+    sha256: "6bf70f4522308de1941200f8cdb9bde6967ba7aacb03445e9d136a5dd812b728"
+  "2.0.30":
+    url: https://github.com/emscripten-core/emsdk/archive/refs/tags/2.0.30.tar.gz
+    sha256: 69050d76c8907a58f99b08831e8cb7a4fba857efec6037d5e59df4b73111ba36

--- a/recipes/emsdk/all/conandata.yml
+++ b/recipes/emsdk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.65":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.65.tar.gz"
+    sha256: "6000c66fc5ca81117cbf9f0fd72e288992915bc16df9e6d77c607fab05b472eb"
   "3.1.50":
     url: "https://github.com/emscripten-core/emsdk/archive/3.1.50.tar.gz"
     sha256: "7491a881eb5ee15fe81bbabcfff1fd571e45ccdb24a81890af429f9970cbd1f3"

--- a/recipes/emsdk/all/conandata.yml
+++ b/recipes/emsdk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.71":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.71.tar.gz"
+    sha256: "ea1bbd1974a3323710fc6e585aad20b056fed634df11db2ee3556bfd18e96afd"
   "3.1.65":
     url: "https://github.com/emscripten-core/emsdk/archive/3.1.65.tar.gz"
     sha256: "6000c66fc5ca81117cbf9f0fd72e288992915bc16df9e6d77c607fab05b472eb"

--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -1,0 +1,196 @@
+from conan import ConanFile, conan_version
+from conan.tools.build import cross_building
+from conan.tools.env import Environment
+from conan.tools.files import chdir, copy, get, replace_in_file
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+import json
+import os
+
+required_conan_version = ">=1.52.0"
+
+
+class EmSDKConan(ConanFile):
+    name = "emsdk"
+    description = "Emscripten SDK. Emscripten is an Open Source LLVM to JavaScript compiler"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/kripken/emscripten"
+    topics = ("emsdk", "emscripten", "sdk")
+    license = "MIT"
+    settings = "os", "arch", "compiler", "build_type"
+
+    short_paths = True
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("nodejs/16.3.0")
+        # self.requires("python")  # FIXME: Not available as Conan package
+        # self.requires("wasm")  # FIXME: Not available as Conan package
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    @property
+    def _relative_paths(self):
+        return ["bin", os.path.join("bin", "upstream", "emscripten")]
+
+    @property
+    def _paths(self):
+        return [os.path.join(self.package_folder, path) for path in self._relative_paths]
+
+    @property
+    def _emsdk(self):
+        return os.path.join(self.package_folder, "bin")
+
+    @property
+    def _emscripten(self):
+        return os.path.join(self.package_folder, "bin", "upstream", "emscripten")
+
+    @property
+    def _em_config(self):
+        return os.path.join(self.package_folder, "bin", ".emscripten")
+
+    @property
+    def _em_cache(self):
+        return os.path.join(self.package_folder, "bin", ".emscripten_cache")
+
+    def generate(self):
+        env = Environment()
+        env.prepend_path("PATH", self._paths)
+        env.define_path("EMSDK", self._emsdk)
+        env.define_path("EMSCRIPTEN", self._emscripten)
+        env.define_path("EM_CONFIG", self._em_config)
+        env.define_path("EM_CACHE", self._em_cache)
+        env.vars(self, scope="emsdk").save_script("emsdk_env_file")
+
+    @staticmethod
+    def _chmod_plus_x(filename):
+        if os.name == "posix":
+            os.chmod(filename, os.stat(filename).st_mode | 0o111)
+
+    def _tools_for_version(self):
+        ret = {}
+        # Select release-upstream from version (wasm-binaries)
+        with open(os.path.join(self.source_folder, "emscripten-releases-tags.json"), "r") as f:
+            data = json.load(f)
+            ret["wasm"] = f"releases-upstream-{data['releases'][self.version]}-64bit"
+        # Select python and node versions
+        with open(os.path.join(self.source_folder, "emsdk_manifest.json"), "r") as f:
+            data = json.load(f)
+            tools = data["tools"]
+            if self.settings.os == "Windows":
+                python = next((it for it in tools if (it["id"] == "python" and not it.get("is_old", False))), None)
+                ret["python"] = f"python-{python['version']}-64bit"
+            node = next((it for it in tools if (it["id"] == "node" and not it.get("is_old", False))), None)
+            ret["nodejs"] = f"node-{node['version']}-64bit"
+        return ret
+
+    def build(self):
+        with chdir(self, self.source_folder):
+            emsdk = "emsdk.bat" if self._settings_build.os == "Windows" else "./emsdk"
+            self._chmod_plus_x("emsdk")
+
+            # Install required tools
+            required_tools = self._tools_for_version()
+            for key, value in required_tools.items():
+                if key != 'nodejs':
+                    self.run(f"{emsdk} install {value}")
+                    self.run(f"{emsdk} activate {value}")
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*", src=self.source_folder, dst=os.path.join(self.package_folder, "bin"))
+        emscripten = os.path.join(self.package_folder, "bin", "upstream", "emscripten")
+        toolchain = os.path.join(emscripten, "cmake", "Modules", "Platform", "Emscripten.cmake")
+        # FIXME: conan should add the root of conan package requirements to CMAKE_PREFIX_PATH (LIBRARY/INCLUDE -> ONLY; PROGRAM -> NEVER)
+        # allow to find conan libraries
+        replace_in_file(self, toolchain,
+                              "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)",
+                              "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)")
+        replace_in_file(self, toolchain,
+                              "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)",
+                              "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)")
+        replace_in_file(self, toolchain,
+                              "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)",
+                              "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)")
+        if not cross_building(self):
+            self.run("embuilder build MINIMAL", env=["conanemsdk", "conanrun"]) # force cache population
+            # the line below forces emscripten to accept the cache as-is, even after re-location
+            # https://github.com/emscripten-core/emscripten/issues/15053#issuecomment-920950710
+            os.remove(os.path.join(self._em_cache, "sanity.txt"))
+
+    def _define_tool_var(self, value):
+        suffix = ".bat" if self.settings.os == "Windows" else ""
+        path = os.path.join(self._emscripten, f"{value}{suffix}")
+        self._chmod_plus_x(path)
+        return path
+
+    def package_info(self):
+        self.cpp_info.bindirs = self._relative_paths
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
+
+        # If we are not building for Emscripten, probably we don't want to inject following environment variables,
+        #   but it might be legit use cases... until we find them, let's be conservative.
+        if not hasattr(self, "settings_target") or self.settings_target is None:
+            return
+
+        if self.settings_target.os != "Emscripten":
+            self.output.warning(f"You've added {self.name}/{self.version} as a build requirement, while os={self.settings_target.os} != Emscripten")
+            return
+
+        toolchain = os.path.join(self.package_folder, "bin", "upstream", "emscripten", "cmake", "Modules", "Platform", "Emscripten.cmake")
+        self.conf_info.prepend("tools.cmake.cmaketoolchain:user_toolchain", toolchain)
+
+        self.buildenv_info.define_path("EMSDK", self._emsdk)
+        self.buildenv_info.define_path("EMSCRIPTEN", self._emscripten)
+        self.buildenv_info.define_path("EM_CONFIG", self._em_config)
+        self.buildenv_info.define_path("EM_CACHE",  self._em_cache)
+
+        compiler_executables = {
+            "c": self._define_tool_var("emcc"),
+            "cpp": self._define_tool_var("em++"),
+        }
+        self.conf_info.update("tools.build:compiler_executables", compiler_executables)
+        self.buildenv_info.define_path("CC", compiler_executables["c"])
+        self.buildenv_info.define_path("CXX", compiler_executables["cpp"])
+        self.buildenv_info.define_path("AR", self._define_tool_var("emar"))
+        self.buildenv_info.define_path("NM", self._define_tool_var("emnm"))
+        self.buildenv_info.define_path("RANLIB", self._define_tool_var("emranlib"))
+        self.buildenv_info.define_path("STRIP", self._define_tool_var("emstrip"))
+
+        self.cpp_info.builddirs = [
+            os.path.join("bin", "releases", "src"),
+            os.path.join("bin", "upstream", "emscripten", "cmake", "Modules"),
+            os.path.join("bin", "upstream", "emscripten", "cmake", "Modules", "Platform"),
+            os.path.join("bin", "upstream", "emscripten", "system", "lib", "libunwind", "cmake", "Modules"),
+            os.path.join("bin", "upstream", "emscripten", "system", "lib", "libunwind", "cmake"),
+            os.path.join("bin", "upstream", "emscripten", "tests", "cmake", "target_library"),
+            os.path.join("bin", "upstream", "lib", "cmake", "llvm"),
+        ]
+
+        if Version(conan_version).major < 2:
+            self.env_info.PATH.extend(self._paths)
+            self.env_info.CONAN_CMAKE_TOOLCHAIN_FILE = toolchain
+            self.env_info.EMSDK = self._emsdk
+            self.env_info.EMSCRIPTEN = self._emscripten
+            self.env_info.EM_CONFIG = self._em_config
+            self.env_info.EM_CACHE = self._em_cache
+            self.env_info.CC = compiler_executables["c"]
+            self.env_info.CXX = compiler_executables["cpp"]
+            self.env_info.AR = self._define_tool_var("emar")
+            self.env_info.NM = self._define_tool_var("emnm")
+            self.env_info.RANLIB = self._define_tool_var("emranlib")
+            self.env_info.STRIP = self._define_tool_var("emstrip")

--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -28,8 +28,8 @@ class EmSDKConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
-    def requirements(self):
-        self.requires("nodejs/16.3.0")
+    def build_requirements(self):
+        self.test_requires("nodejs/20.16.0")
         # self.requires("python")  # FIXME: Not available as Conan package
         # self.requires("wasm")  # FIXME: Not available as Conan package
 
@@ -129,6 +129,7 @@ class EmSDKConan(ConanFile):
             # the line below forces emscripten to accept the cache as-is, even after re-location
             # https://github.com/emscripten-core/emscripten/issues/15053#issuecomment-920950710
             os.remove(os.path.join(self._em_cache, "sanity.txt"))
+            self.run("npm install -g typescript", env=["conanemsdk", "conanrun", "conanbuild"])
 
     def _define_tool_var(self, value):
         suffix = ".bat" if self.settings.os == "Windows" else ""

--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -130,7 +130,7 @@ class EmSDKConan(ConanFile):
             # the line below forces emscripten to accept the cache as-is, even after re-location
             # https://github.com/emscripten-core/emscripten/issues/15053#issuecomment-920950710
             os.remove(os.path.join(self._em_cache, "sanity.txt"))
-            self.run("npm install -g typescript", env=["conanemsdk", "conanrun", "conanbuild"])
+            self.run("npm install", cwd=emscripten, env=["conanemsdk", "conanrun", "conanbuild"])
 
     def _define_tool_var(self, value):
         suffix = ".bat" if self.settings.os == "Windows" else ""

--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -7,6 +7,7 @@ from conan.tools.scm import Version
 import json
 import os
 
+
 required_conan_version = ">=1.52.0"
 
 

--- a/recipes/emsdk/all/test_package/CMakeLists.txt
+++ b/recipes/emsdk/all/test_package/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES CXX)
+
+add_executable(${PROJECT_NAME} test_package.cpp)

--- a/recipes/emsdk/all/test_package/conanfile.py
+++ b/recipes/emsdk/all/test_package/conanfile.py
@@ -1,0 +1,40 @@
+from conan import ConanFile
+from conan.tools.env import Environment
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        if self.settings.os == "Emscripten":
+            env = Environment()
+            env.define_path("EM_CACHE", os.path.join(self.build_folder, ".emcache"))
+            envvars = env.vars(self, scope="build")
+            envvars.save_script("em_cache")
+
+    def build(self):
+        # It only makes sense to build a library, if the target os is Emscripten
+        if self.settings.os == "Emscripten":
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+
+    def test(self):
+        # Check the package provides working binaries
+        self.run("emcc -v")
+        self.run("em++ -v")
+
+        # Run the project that was built using emsdk
+        if self.settings.os == "Emscripten":
+            test_file = os.path.join(self.cpp.build.bindirs[0], "test_package.js")
+            self.run(f"node {test_file}")

--- a/recipes/emsdk/all/test_package/test_package.cpp
+++ b/recipes/emsdk/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <cstdlib>
+#include <iostream>
+
+int main()
+{
+    std::cout << "conan-center-index\n";
+    return EXIT_SUCCESS;
+}

--- a/recipes/emsdk/all/test_v1_package/CMakeLists.txt
+++ b/recipes/emsdk/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)

--- a/recipes/emsdk/all/test_v1_package/conanfile.py
+++ b/recipes/emsdk/all/test_v1_package/conanfile.py
@@ -1,0 +1,30 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+    generators = "cmake"
+
+    def build_requirements(self):
+        self.build_requires(self.tested_reference_str)
+
+    def build(self):
+        # It only makes sense to build a library, if the target os is Emscripten
+        if self.settings.os == "Emscripten":
+            with tools.environment_append({"EM_CACHE": os.path.join(self.build_folder, ".emcache")}):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+
+    def test(self):
+        # Check the package provides working binaries
+        if not tools.cross_building(self):
+            self.run("emcc -v", run_environment=True)
+            self.run("em++ -v", run_environment=True)
+
+        # Run the project that was built using emsdk
+        if self.settings.os == "Emscripten":
+            test_file = os.path.join("bin", "test_package.js")
+            self.run(f"node {test_file}", run_environment=True)

--- a/recipes/emsdk/config.yml
+++ b/recipes/emsdk/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "3.1.65":
+    folder: all
   "3.1.50":
     folder: all

--- a/recipes/emsdk/config.yml
+++ b/recipes/emsdk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.1.71":
+    folder: all
   "3.1.65":
     folder: all
   "3.1.50":

--- a/recipes/emsdk/config.yml
+++ b/recipes/emsdk/config.yml
@@ -1,6 +1,8 @@
 versions:
   "3.1.71":
     folder: all
+  "3.1.70":
+    folder: all
   "3.1.65":
     folder: all
   "3.1.50":

--- a/recipes/emsdk/config.yml
+++ b/recipes/emsdk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.1.50":
+    folder: all

--- a/recipes/foonathan-lexy/all/conandata.yml
+++ b/recipes/foonathan-lexy/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "2022.12.1":
+    url: "https://github.com/foonathan/lexy/releases/download/v2022.12.1/lexy-src.zip"
+    sha256: "4c16efd31d03f908c7125352ebacbdb6c028de3788ca56940175e7017dbc6c7f"
+  "2022.12.00":
+    url: "https://github.com/foonathan/lexy/releases/download/v2022.12.0/lexy-src.zip"
+    sha256: "62afda502963abce28f051416b977dcc8f11581ba0773f4b1da39a9b4842b19d"
+  "2022.05.01":
+    url: "https://github.com/foonathan/lexy/releases/download/v2022.05.1/lexy-src.zip"
+    sha256: "de2199f8233ea5ed9d4dbe86a8eaf88d754decd28e28554329a7b29b4d952773"

--- a/recipes/foonathan-lexy/all/conandata.yml
+++ b/recipes/foonathan-lexy/all/conandata.yml
@@ -8,3 +8,10 @@ sources:
   "2022.05.01":
     url: "https://github.com/foonathan/lexy/releases/download/v2022.05.1/lexy-src.zip"
     sha256: "de2199f8233ea5ed9d4dbe86a8eaf88d754decd28e28554329a7b29b4d952773"
+patches:
+  "2022.12.1":
+    - patch_file: "patches/2022.12.1-0001-lexy_input_location_comparison_fix.diff"
+      patch_description: "Fix typo in lexy::input_location comparison"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/foonathan/lexy/commit/e8eb4d67c4eb33e1476218c0374f68e198723526"
+

--- a/recipes/foonathan-lexy/all/conanfile.py
+++ b/recipes/foonathan-lexy/all/conanfile.py
@@ -1,0 +1,104 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import get, copy, rm, rmdir
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+import os
+
+required_conan_version = ">=1.53.0"
+
+class FoonathanLexyConan(ConanFile):
+    name = "foonathan-lexy"
+    description = "lexy is a parser combinator library for C++17 and onwards."
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/foonathan/lexy"
+    topics = ("parser", "parser-combinators", "grammar")
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "16",
+            "msvc": "192",
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "10",
+        }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.info.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.18 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["LEXY_BUILD_EXAMPLES"] = False
+        tc.variables["LEXY_BUILD_TESTS"] = False
+        tc.variables["LEXY_BUILD_PACKAGE"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "lexy")
+        self.cpp_info.set_property("cmake_target_name", "foonathan::lexy")
+
+        self.cpp_info.components["lexy_core"].set_property("cmake_target_name", "foonathan::lexy::lexy_core")
+
+        self.cpp_info.components["lexy_file"].set_property("cmake_target_name", "foonathan::lexy::lexy_file")
+        self.cpp_info.components["lexy_file"].libs = ["lexy_file"]
+
+        self.cpp_info.components["lexy_unicode"].set_property("cmake_target_name", "lexy::lexy_unicode")
+        self.cpp_info.components["lexy_unicode"].defines.append("LEXY_HAS_UNICODE_DATABASE=1")
+
+        self.cpp_info.components["lexy_ext"].set_property("cmake_target_name", "lexy::lexy_ext")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "lexy"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "lexy"
+        self.cpp_info.names["cmake_find_package"] = "foonathan"
+        self.cpp_info.names["cmake_find_package_multi"] = "foonathan"
+        self.cpp_info.components["foonathan"].names["cmake_find_package"] = "lexy"
+        self.cpp_info.components["foonathan"].names["cmake_find_package_multi"] = "lexy"

--- a/recipes/foonathan-lexy/all/conanfile.py
+++ b/recipes/foonathan-lexy/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import get, copy, rm, rmdir
+from conan.tools.files import get, copy, rm, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
@@ -57,6 +57,9 @@ class FoonathanLexyConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.18 <4]")
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder)
 
@@ -68,6 +71,7 @@ class FoonathanLexyConan(ConanFile):
         tc.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/foonathan-lexy/all/patches/2022.12.1-0001-lexy_input_location_comparison_fix.diff
+++ b/recipes/foonathan-lexy/all/patches/2022.12.1-0001-lexy_input_location_comparison_fix.diff
@@ -1,0 +1,13 @@
+diff --git a/include/lexy/input_location.hpp b/include/lexy/input_location.hpp
+index 55f6edb7..983d2aa0 100644
+--- a/include/lexy/input_location.hpp
++++ b/include/lexy/input_location.hpp
+@@ -162,7 +162,7 @@ class input_location
+     {
+         if (lhs._line_nr != rhs._line_nr)
+             return lhs._line_nr < rhs._line_nr;
+-        return lhs._column_nr < rhs._colum_nr;
++        return lhs._column_nr < rhs._column_nr;
+     }
+     friend constexpr bool operator<=(const input_location& lhs, const input_location& rhs)
+     {

--- a/recipes/foonathan-lexy/all/test_package/CMakeLists.txt
+++ b/recipes/foonathan-lexy/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package LANGUAGES CXX)
+
+find_package(lexy REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE foonathan::lexy)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/foonathan-lexy/all/test_package/conanfile.py
+++ b/recipes/foonathan-lexy/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/foonathan-lexy/all/test_package/test_package.cpp
+++ b/recipes/foonathan-lexy/all/test_package/test_package.cpp
@@ -1,0 +1,43 @@
+#include <cstdio>
+
+#include <lexy/action/parse.hpp>
+#include <lexy/callback.hpp>
+#include <lexy/dsl.hpp>
+#include <lexy/input/string_input.hpp>
+#include <lexy_ext/report_error.hpp>
+
+struct Color
+{
+    std::uint8_t r, g, b;
+};
+
+namespace grammar
+{
+namespace dsl = lexy::dsl;
+
+struct channel
+{
+    static constexpr auto rule  = dsl::integer<std::uint8_t>(dsl::n_digits<2, dsl::hex>);
+    static constexpr auto value = lexy::forward<std::uint8_t>;
+};
+
+struct color
+{
+    static constexpr auto rule  = dsl::hash_sign + dsl::times<3>(dsl::p<channel>);
+    static constexpr auto value = lexy::construct<Color>;
+};
+} // namespace grammar
+
+int main() {
+    unsigned char array[] = {'#', '5', '5', 'A', 'A', '0', '5'};
+
+    auto input = lexy::string_input(array, array + 7);
+    auto result = lexy::parse<grammar::color>(input, lexy_ext::report_error);
+    if (result.has_value())
+    {
+        auto color = result.value();
+        std::printf("#%02x%02x%02x\n", color.r, color.g, color.b);
+    }
+
+    return result ? 0 : 1;
+}

--- a/recipes/foonathan-lexy/all/test_v1_package/CMakeLists.txt
+++ b/recipes/foonathan-lexy/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/foonathan-lexy/all/test_v1_package/conanfile.py
+++ b/recipes/foonathan-lexy/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/foonathan-lexy/config.yml
+++ b/recipes/foonathan-lexy/config.yml
@@ -1,0 +1,7 @@
+versions:
+  "2022.12.1":
+    folder: all
+  "2022.12.00":
+    folder: all
+  "2022.05.01":
+    folder: all

--- a/recipes/foonathan-lexy/config.yml
+++ b/recipes/foonathan-lexy/config.yml
@@ -1,7 +1,3 @@
 versions:
   "2022.12.1":
     folder: all
-  "2022.12.00":
-    folder: all
-  "2022.05.01":
-    folder: all

--- a/recipes/nodejs/all/conandata.yml
+++ b/recipes/nodejs/all/conandata.yml
@@ -1,0 +1,118 @@
+sources:
+    "20.16.0":
+        Windows:
+            "x86_64":
+                url: "https://nodejs.org/dist/v20.16.0/node-v20.16.0-win-x64.zip"
+                sha256: "4e88373ac5ae859ad4d50cc3c5fa86eb3178d089b72e64c4dbe6eeac5d7b5979"
+            "armv8":
+                url: "https://nodejs.org/dist/v20.16.0/node-v20.16.0-win-arm64.zip"
+                sha256: "af5a85ea299fcebd34c3c726a47a926e73171f9b657a6eaa796c011597241bf8"
+        Linux:
+            "x86_64":
+                url: "https://nodejs.org/dist/v20.16.0/node-v20.16.0-linux-x64.tar.xz"
+                sha256: "c30af7dfea46de7d8b9b370fa33b8b15440bc93f0a686af8601bbb48b82f16c0"
+            "armv7":
+                url: "https://nodejs.org/dist/v20.16.0/node-v20.16.0-linux-armv7l.tar.xz"
+                sha256: "a23a49029e8c7788c701eb3ace553260b7676a5a2ea9965ba92e4817008fbefe"
+            "armv8":
+                url: "https://nodejs.org/dist/v20.16.0/node-v20.16.0-linux-arm64.tar.xz"
+                sha256: "1d9929e72f692179f884cd676b2dfabd879cb77defa7869dc8cfc802619277fb"
+        Macos:
+            "x86_64":
+                url: "https://nodejs.org/dist/v20.16.0/node-v20.16.0-darwin-x64.tar.gz"
+                sha256: "e18942cd706e4d69a4845ddacee2f1c17a72e853a229e3d2623d2edeb7efde72"
+            "armv8":
+                url: "https://nodejs.org/dist/v20.16.0/node-v20.16.0-darwin-arm64.tar.gz"
+                sha256: "fc7355e778b181575153b7dea4879e8021776eeb376c43c50f65893d2ea70aa3"
+    "18.15.0":
+        Windows:
+            "x86_64":
+                url: "https://nodejs.org/dist/v18.15.0/node-v18.15.0-win-x64.zip"
+                sha256: "118fbcae58bc8c53cbe97a10c019734ed90685da8dda98aa0b0f4aeead42a647"
+        Linux:
+            "x86_64":
+                url: "https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-x64.tar.xz"
+                sha256: "c8c5fa53ce0c0f248e45983e86368e0b1daf84b77e88b310f769c3cfc12682ef"
+            "armv7":
+                url: "https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-armv7l.tar.xz"
+                sha256: "baad3cdf1365f46bf837635554b10bc3e320799e69ac26e07df1fcde0c1738c7"
+            "armv8":
+                url: "https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-arm64.tar.xz"
+                sha256: "98ea6ed0a1ae55334ab2c03c34d5e52c6dc3dee8f236c0afc08ab1c964506633"
+        Macos:
+            "x86_64":
+                url: "https://nodejs.org/dist/v18.15.0/node-v18.15.0-darwin-x64.tar.gz"
+                sha256: "76add174d2d3f98da08907412e82add7352b8cb6f639324d352a65c084b99c7e"
+            "armv8":
+                url: "https://nodejs.org/dist/v18.15.0/node-v18.15.0-darwin-arm64.tar.gz"
+                sha256: "bd302a689c3c34e2b61d86b97de66d26a335881a17af09b6a0a4bb1019df56e4"
+    "16.20.2":
+        Windows:
+            "x86_64":
+                url: "https://nodejs.org/dist/v16.20.2/node-v16.20.2-win-x64.zip"
+                sha256: "f8bb35f6c08dc7bf14ac753509c06ed1a7ebf5b390cd3fbdc8f8c1aedd020ec3"
+        Linux:
+            "x86_64":
+                url: "https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz"
+                sha256: "874463523f26ed528634580247f403d200ba17a31adf2de98a7b124c6eb33d87"
+            "armv7":
+                url: "https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-armv7l.tar.xz"
+                sha256: "5f2a2a34d2f19931b8ef39416bde96933e6666f91a2d1a2b92af30627a8e8429"
+            "armv8":
+                url: "https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-arm64.tar.xz"
+                sha256: "e88d86154d1ce53dc52fd74d79d4bfdf0b05f58c0bb2639adfa36e9378b770c4"
+        Macos:
+            "x86_64":
+                url: "https://nodejs.org/dist/v16.20.2/node-v16.20.2-darwin-x64.tar.gz"
+                sha256: "d7a46eaf2b57ffddeda16ece0d887feb2e31a91ad33f8774da553da0249dc4a6"
+            "armv8":
+                url: "https://nodejs.org/dist/v16.20.2/node-v16.20.2-darwin-arm64.tar.gz"
+                sha256: "6a5c4108475871362d742b988566f3fe307f6a67ce14634eb3fbceb4f9eea88c"
+    "16.3.0":
+        Windows:
+            "x86_64":
+                url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-win-x64.zip"
+                sha256: "3352e58d3603cf58964409d07f39f3816285317d638ddb0a0bf3af5deb2ff364"
+        Linux:
+            "x86_64":
+                url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-x64.tar.xz"
+                sha256: "5347ece975747e4d9768d4ed3f8b2220c955ac01f8a695347cd7f71ff5efa318"
+            "armv7":
+                url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-armv7l.tar.xz"
+                sha256: "c8817e30fb910476ec1f223de7eedd31f3d157ddf2003a3083d7f5662180e4de"
+            "armv8":
+                url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-arm64.tar.xz"
+                sha256: "67dd97e41aad1bc11736e99cba119525b4f3472b132c46730ba8cf03f7076e23"
+        Macos:
+            "x86_64":
+                url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-x64.tar.gz"
+                sha256: "3e075bcfb6130dda84bfd04633cb228ec71e72d9a844c57efb7cfff130b4be89"
+            "armv8":
+                url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-arm64.tar.gz"
+                sha256: "aeac294dbe54a4dfd222eedfbae704b185c40702254810e2c5917f6dbc80e017"
+    "13.6.0":
+        Windows:
+            "x86_64":
+                url: "https://nodejs.org/dist/v13.6.0/node-v13.6.0-win-x64.zip"
+                sha256: "7fe37b34a4673a071bea52fcaf913ec422cf6fd79fd025bfb22de42ccc77f386"
+        Linux:
+            "x86_64":
+                url: "https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-x64.tar.xz"
+                sha256: "00f01315a867da16d1638f7a02966c608e344ac6c5b7d04d1fdae3138fa9d798"
+        Macos:
+            "x86_64":
+                url: "https://nodejs.org/dist/v13.6.0/node-v13.6.0-darwin-x64.tar.gz"
+                sha256: "da13adb864777b322dda7af20410a9b0c63aa69de4b5574008d1e6910768bf69"
+    "12.14.1":
+        Windows:
+            "x86_64":
+                url: "https://nodejs.org/dist/v12.14.1/node-v12.14.1-win-x64.zip"
+                sha256: "1f96ccce3ba045ecea3f458e189500adb90b8bc1a34de5d82fc10a5bf66ce7e3"
+        Linux:
+            "x86_64":
+                url: "https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-x64.tar.xz"
+                sha256: "07cfcaa0aa9d0fcb6e99725408d9e0b07be03b844701588e3ab5dbc395b98e1b"
+        Macos:
+            "x86_64":
+                url: "https://nodejs.org/dist/v12.14.1/node-v12.14.1-darwin-x64.tar.gz"
+                sha256: "0be10a28737527a1e5e3784d3ad844d742fe8b0718acd701fd48f718fd3af78f"

--- a/recipes/nodejs/all/conanfile.py
+++ b/recipes/nodejs/all/conanfile.py
@@ -1,0 +1,66 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get
+
+required_conan_version = ">=1.59.0"
+
+
+class NodejsConan(ConanFile):
+    name = "nodejs"
+    description = "Node.js is an open-source, cross-platform JavaScript runtime environment."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://nodejs.org"
+    topics = ("node", "javascript", "runtime", "pre-built")
+
+    package_type = "application"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+    short_paths = True
+
+    def layout(self):
+        pass
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+    @property
+    def _nodejs_arch(self):
+        if str(self.settings.os) in ["Linux", "FreeBSD"]:
+            if str(self.settings.arch).startswith("armv7"):
+                return "armv7"
+            if str(self.settings.arch).startswith("armv8") and "32" not in str(self.settings.arch):
+                return "armv8"
+        return str(self.settings.arch)
+
+    @property
+    def _dl_info(self):
+        return self.conan_data["sources"].get(self.version, {}).get(str(self.settings.os), {}).get(self._nodejs_arch)
+
+    def validate(self):
+        if not self._dl_info:
+            raise ConanInvalidConfiguration("Binaries for this combination of architecture/version/os not available")
+
+    def build(self):
+        get(self, **self._dl_info, strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.build_folder)
+        copy(self, "*", dst=os.path.join(self.package_folder, "bin"), src=os.path.join(self.build_folder, "bin"))
+        copy(self, "*", dst=os.path.join(self.package_folder, "lib"), src=os.path.join(self.build_folder, "lib"))
+        copy(self, "node.exe", dst=os.path.join(self.package_folder, "bin"), src=self.build_folder)
+        copy(self, "npm", dst=os.path.join(self.package_folder, "bin"), src=self.build_folder)
+        copy(self, "npx", dst=os.path.join(self.package_folder, "bin"), src=self.build_folder)
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
+
+        # TODO: Legacy, to be removed on Conan 2.0
+        bin_dir = os.path.join(self.package_folder, "bin")
+        self.env_info.PATH.append(bin_dir)

--- a/recipes/nodejs/all/conanfile.py
+++ b/recipes/nodejs/all/conanfile.py
@@ -64,3 +64,6 @@ class NodejsConan(ConanFile):
         # TODO: Legacy, to be removed on Conan 2.0
         bin_dir = os.path.join(self.package_folder, "bin")
         self.env_info.PATH.append(bin_dir)
+        self.buildenv_info.append_path("PATH", bin_dir)
+        self.env_info.PATH.append(os.path.join(self.package_folder, "lib", "node_modules", ".bin"))
+        self.buildenv_info.append_path("PATH", os.path.join(self.package_folder, "lib", "node_modules", ".bin"))

--- a/recipes/nodejs/all/conanfile.py
+++ b/recipes/nodejs/all/conanfile.py
@@ -4,6 +4,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import copy, get
 
+
 required_conan_version = ">=1.59.0"
 
 

--- a/recipes/nodejs/all/test_package/conanfile.py
+++ b/recipes/nodejs/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import platform
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout
+from conan.tools.scm import Version
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        if can_run(self):
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                libc_version = Version(platform.libc_ver()[1])
+                if libc_version < "2.29":
+                    self.output.warning(f"System libc version {libc_version} < 2.29, skipping test_package")
+                    return
+            self.run("node --version")

--- a/recipes/nodejs/all/test_v1_package/conanfile.py
+++ b/recipes/nodejs/all/test_v1_package/conanfile.py
@@ -1,0 +1,24 @@
+import platform
+
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conans.model.version import Version
+
+
+class TestPackageConan(ConanFile):
+
+    settings = "os", "arch"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.build_requires(self.tested_reference_str)
+
+    def test(self):
+        if not cross_building(self):
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                libc_version = Version(platform.libc_ver()[1])
+                if libc_version < "2.29":
+                    self.output.warning(f"System libc version {libc_version} < 2.29, skipping test_package")
+                    return
+            self.output.info("Node version:")
+            self.run("node --version")

--- a/recipes/nodejs/config.yml
+++ b/recipes/nodejs/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "20.16.0":
+    folder: all


### PR DESCRIPTION
CCI doens't have the newer Emsdk version yet. We need this for the `std::optional` binding and better generated TypeScript files.

Also added a custom foonathan-lexy recipe with a fix that isn't released yet. Because the newer Emsdk uses a higher Clang version we're suddenly compiling that function with `constexpr` this pathces the recipe.

The recipes contain some quick specific hack and are not CCI worthy. I will open up an issue at the CCI to upgrade Emsdk and fix nodejs later this sprint.

> [!TIP]
> **Don't review the whole recipe**, it is copied pasted from CCI https://github.com/conan-io/conan-center-index/ just focus on the changes that I needed to make, in the GH workflows and the actual changes to the recipe are in these commits:
> - https://github.com/Ultimaker/conan-ultimaker-index/pull/14/commits/e15b699f09a33a1ed4d070ca12bd63d049b81cea 
> - https://github.com/Ultimaker/conan-ultimaker-index/commit/9fc78ec3dddd527b6bd838f7939311bc6fd636a2
> - https://github.com/Ultimaker/conan-ultimaker-index/pull/14/commits/162eeb53d59863433975d03cb2f532d86815199d
