### PR TITLE
Update CMake minimum versions and improve toolchain setup

### DIFF
--- a/recipes/clipper/all/conanfile.py
+++ b/recipes/clipper/all/conanfile.py
@@ -17,8 +17,8 @@ class ClipperConan(ConanFile):
     topics = ("clipping", "polygon")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://www.angusj.com/delphi/clipper.php"
-    settings = "os", "arch", "compiler", "build_type"
     package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
     python_requires = "sentrylibrary/1.0.0"
     python_requires_extend = "sentrylibrary.SentryLibrary"
 
@@ -60,8 +60,9 @@ class ClipperConan(ConanFile):
         tc = CMakeToolchain(self)
         # Export symbols for msvc shared
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
-        # To install relocatable shared libs on Macos
+        # Relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         self.setup_cmake_toolchain_sentry(tc)
         tc.generate()
 

--- a/recipes/clipper/all/test_package/CMakeLists.txt
+++ b/recipes/clipper/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(clipper REQUIRED CONFIG)


### PR DESCRIPTION
Increased CMake minimum version to 3.15 in the test package and added a policy version minimum in the toolchain for better compatibility with newer CMake versions. same as conan-center-index

see https://github.com/Ultimaker/conan-ultimaker-index/pull/21, reopened another one to create a package 

NP-558