### PR TITLE
Remove deprecated CMake name assignments for clipper

### DIFF
--- a/recipes/clipper/all/conanfile.py
+++ b/recipes/clipper/all/conanfile.py
@@ -87,8 +87,3 @@ class ClipperConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
 
-        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed.
-        #       Do not use these CMake names in CMakeDeps, it was a mistake,
-        #       clipper doesn't provide CMake config file
-        self.cpp_info.names["cmake_find_package"] = "polyclipping"
-        self.cpp_info.names["cmake_find_package_multi"] = "polyclipping"


### PR DESCRIPTION
Removed unnecessary CMake name mappings related to outdated `cmake_find_package` and `cmake_find_package_multi` generators. This change aligns with Conan v2 practices and avoids confusion regarding clipper’s CMake config file.